### PR TITLE
Improved action service by adding support for custom href in admin:sidebar and preventing onclick='return false;' if a handler is not set

### DIFF
--- a/twig/service-twig-extensions.php
+++ b/twig/service-twig-extensions.php
@@ -177,7 +177,7 @@ class ServiceTwigExtensions extends \Twig_Extension
                             // The admin sidebar needs the href set.
                             $href = "#";
                             if (isset($service['href'])) {
-                                $href = $service['href']
+                                $href = $service['href'];
                             }
 
                             $class = '';

--- a/twig/service-twig-extensions.php
+++ b/twig/service-twig-extensions.php
@@ -165,9 +165,11 @@ class ServiceTwigExtensions extends \Twig_Extension
                             $strContext = self::stringify($serverCallbackContext);
                             $handler .= "_nonAjaxAction(\"$serverCallbackId\", \"$strContext\", \"$confirmationMessage\");";
                         }
-                        $handler .= "return false;";
-
-                        $handler = "onclick='" . str_replace("'", "\\'", $handler) . "'";
+                        if ($handler !== ""){
+                            $handler .= "return false;";
+    
+                            $handler = "onclick='" . str_replace("'", "\\'", $handler) . "'";
+                        }
 //                        $handler = "onclick=\"" . str_replace("\"", "'", $handler) . "\"";
 
                         if ($scope && in_array("admin:sidebar", $scope)) {

--- a/twig/service-twig-extensions.php
+++ b/twig/service-twig-extensions.php
@@ -173,13 +173,18 @@ class ServiceTwigExtensions extends \Twig_Extension
                         if ($scope && in_array("admin:sidebar", $scope)) {
                             // The admin sidebar CSS only hides caption if it is inside an <em> tag.
                             // The admin sidebar needs the href set.
+                            $href = "#";
+                            if (isset($service['href'])) {
+                                $href = $service['href']
+                            }
+
                             $class = '';
                             if (isset($service['isSelected'])) {
                                 if ($service['isSelected']($context)) {
                                     $class = 'selected';
                                 }
                             }
-                            $out .= "<li class='$class'><a href='#' $handler><i class='fa fa-fw $icon'></i><em>$caption</em></i></a></li>";
+                            $out .= "<li class='$class'><a href='$href' $handler><i class='fa fa-fw $icon'></i><em>$caption</em></i></a></li>";
                         } else if ($scope && in_array("page:more", $scope)) {
                             // This is the format for the Admin titlebar button
                             $out .= "<li><a class='button' $handler><i class='fa $icon'></i>$caption</a></li>";


### PR DESCRIPTION
This should make it easier to create simple admin:sidebar actions that link to an admin plugin page without the need to include a "window.location.href" callback. I have tested it using my [fork of the editor plugin](https://github.com/jac4e/grav-plugin-editor) and it works as intended.